### PR TITLE
Use AudioInfo value to fix crash on MP3 files with no TLEN tag

### DIFF
--- a/mp3chaps.py
+++ b/mp3chaps.py
@@ -12,6 +12,7 @@ Options:
 
 """
 from eyed3.id3 import Tag
+from eyed3 import core
 from docopt import docopt
 import os
 
@@ -41,7 +42,8 @@ def parse_chapters_file(fname):
 
 def add_chapters(tag, fname):
   chaps = parse_chapters_file(fname)
-  total_length = int(tag.getTextFrame('TLEN'))
+  audioFile = core.load(fname)
+  total_length = audioFile.info.time_secs * 1000
   chaps_ = []
   for i, chap in enumerate(chaps):
     if i < (len(chaps)-1):


### PR DESCRIPTION
I was processing a podcast that I had split using ffmpeg. The file had no TLEN tag, so I was getting an exception on line 44, where it was assuming TLEN existed. 

I dug through the API docs for eyeD3 and the fixup plugin to find how they insert the TLEN. It seems rather than ask for the total length, to just query for the length from the AudioInfo class.

http://eyed3.readthedocs.io/en/latest/eyed3.html#module-eyed3.core